### PR TITLE
Fix hard-coded absolute paths in fonts{2,3}go.cgi

### DIFF
--- a/web/server/fonts2go.cgi
+++ b/web/server/fonts2go.cgi
@@ -5,7 +5,7 @@ use strict;
 #
 # Customize these settings as needed for the host system
 #
-my $typeTunerDir = '/var/www/scripts.sil.org/cms/ttw/TypeTuner';
+my $typeTunerDir = 'TypeTuner';
 my $tunableFontsDir = "$typeTunerDir/tunable-fonts";
 my $logDir = '/var/log';
 my $tmpDir = '/tmp';

--- a/web/server/fonts2go.cgi
+++ b/web/server/fonts2go.cgi
@@ -1,11 +1,13 @@
 #!/usr/bin/perl
 
 use strict;  
+use Cwd qw(cwd);
 
 #
 # Customize these settings as needed for the host system
 #
-my $typeTunerDir = 'TypeTuner';
+my $baseDir = cwd;
+my $typeTunerDir = "$baseDir/TypeTuner";
 my $tunableFontsDir = "$typeTunerDir/tunable-fonts";
 my $logDir = '/var/log';
 my $tmpDir = '/tmp';

--- a/web/server/fonts3go.cgi
+++ b/web/server/fonts3go.cgi
@@ -5,7 +5,7 @@ use strict;
 #
 # Customize these settings as needed for the host system
 #
-my $typeTunerDir = '/var/www/scripts.sil.org/cms/ttw/TypeTuner';
+my $typeTunerDir = 'TypeTuner';
 my $tunableFontsDir = "$typeTunerDir/tunable-fonts";
 my $logDir = '/var/log';
 my $tmpDir = '/tmp';

--- a/web/server/fonts3go.cgi
+++ b/web/server/fonts3go.cgi
@@ -1,11 +1,13 @@
 #!/usr/bin/perl
 
 use strict;  
+use Cwd qw(cwd);
 
 #
 # Customize these settings as needed for the host system
 #
-my $typeTunerDir = 'TypeTuner';
+my $baseDir = cwd;
+my $typeTunerDir = "$baseDir/TypeTuner";
 my $tunableFontsDir = "$typeTunerDir/tunable-fonts";
 my $logDir = '/var/log';
 my $tmpDir = '/tmp';


### PR DESCRIPTION
The paths as checked in are incorrect for the server and relative paths will work just as well and provide more future flexibility.